### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ you can use it to add an divider to RecyclerView
 ![default GridLayoutManager](https://github.com/ChoicesWang/RecyclerView_Divider/blob/master/pictures/screen%20%283%29.png)
 ![aglie GridLayoutManager](https://github.com/ChoicesWang/RecyclerView_Divider/blob/master/pictures/screen%20%284%29.png)
 
-##Gradle
+## Gradle
 ```
 repositories {
     jcenter()
@@ -23,7 +23,7 @@ dependencies {
 }
 ```
 
-##Usage
+## Usage
 
 - **Add defualt DividerItemDecoration()**
 - 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
